### PR TITLE
Added [cmd] commands to manage command files from within the server.

### DIFF
--- a/src/main/java/com/carrot/carrotshop/Lang.java
+++ b/src/main/java/com/carrot/carrotshop/Lang.java
@@ -10,6 +10,10 @@ import ninja.leaping.configurate.loader.ConfigurationLoader;
 
 public class Lang
 {
+	public static String COMANDSIGN_UNLINKED = "Commandsign Command Unlinked";
+	public static String COMANDSIGN_LINKED = "Commandsign Command Linked";
+	public static String COMANDSIGN_LINKED_SIGN = "Successfully linked command";
+
 	public static String HELP_DESC_CMD_REPORT = "Generare a CarrotShop report";
 	public static String HELP_DESC_CMD_SREPORT = "Generare a CarrotShop report for iSigns";
 	public static String HELP_DESC_CMD_OREPORT = "Generate a CarrotShop report for another player";
@@ -20,9 +24,19 @@ public class Lang
 	public static String HELP_DESC_CMD_CONFIG = "Change or reload config of the plugin";
 	public static String HELP_DESC_CMD_MAIN = "Main CarrotShop command";
 	public static String HELP_DESC_CMD_IMPORT = "Import shop data from another plugin";
+	public static String HELP_DESC_CMD_COMMANDSIGN = "Commands relating to command signs";
+	public static String HELP_DESC_CMD_COMMANDSIGN_LINK = "links the commandsign to a commandsign command";
+    public static String HELP_DESC_CMD_COMMANDSIGN_LIST = "lists all commandsign commands";
+    public static String HELP_DESC_CMD_COMMANDSIGN_REMOVE = "removes a commandsign command";
+	public static String HELP_DESC_CMD_COMMANDSIGN_SET = "Sets a commandsign command";
+
+	public static String HOVER_ACTION_REMOVE = "Remove";
+	public static String HOVER_ACTION_LINK = "Link";
 	
 	public static String HELP_HEADER_CMD_MAIN = "/carrotshop";
 	public static String HELP_HEADER_CMD_CONFIG = "/carrotshop config";
+	public static String HELP_HEADER_CMD_COMMANDSIGN = "/carrotshop command";
+	public static String HELP_HEADER_CMD_COMMANDSIGN_LIST = "/carrotshop command list";
 
 	public static String STATUS_ON = "ON";
 	public static String STATUS_OFF = "OFF";

--- a/src/main/java/com/carrot/carrotshop/command/ShopCommandSignLinkExecutor.java
+++ b/src/main/java/com/carrot/carrotshop/command/ShopCommandSignLinkExecutor.java
@@ -1,0 +1,37 @@
+package com.carrot.carrotshop.command;
+
+import com.carrot.carrotshop.CarrotShop;
+import com.carrot.carrotshop.Lang;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import javax.swing.text.html.Option;
+import java.util.Optional;
+
+public class ShopCommandSignLinkExecutor implements CommandExecutor {
+
+    @Override
+    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+        Optional<String> command = args.<String>getOne("name");
+
+        if (src instanceof Player) {
+            if (command.isPresent()){
+                CarrotShop.setLinkedCommand(((Player) src).getUniqueId(), command.get());
+                src.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.COMANDSIGN_LINKED ));
+            } else {
+                CarrotShop.removeLinkedCommand(((Player) src).getUniqueId());
+                src.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.COMANDSIGN_UNLINKED ));
+            }
+        }
+
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/carrot/carrotshop/command/ShopCommandSignListExecutor.java
+++ b/src/main/java/com/carrot/carrotshop/command/ShopCommandSignListExecutor.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotshop.command;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import com.carrot.carrotshop.util.CommandSignList;
+
+public class ShopCommandSignListExecutor implements CommandExecutor {
+
+    @Override
+    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+        CommandSignList.build(src).sendTo(src);
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/carrot/carrotshop/command/ShopCommandSignMainExecutor.java
+++ b/src/main/java/com/carrot/carrotshop/command/ShopCommandSignMainExecutor.java
@@ -1,0 +1,36 @@
+package com.carrot.carrotshop.command;
+
+import com.carrot.carrotshop.Lang;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShopCommandSignMainExecutor implements CommandExecutor {
+
+    @Override
+    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+        List<Text> contents = new ArrayList<>();
+
+        contents.add(Text.of(TextColors.GOLD, "/cs cmd list", TextColors.GRAY, " - ", TextColors.YELLOW, Lang.HELP_DESC_CMD_COMMANDSIGN_LIST));
+        contents.add(Text.of(TextColors.GOLD, "/cs cmd link", TextColors.GRAY, " - ", TextColors.YELLOW, Lang.HELP_DESC_CMD_COMMANDSIGN_LINK));
+        contents.add(Text.of(TextColors.GOLD, "/cs cmd set", TextColors.GRAY, " - ", TextColors.YELLOW, Lang.HELP_DESC_CMD_COMMANDSIGN_SET));
+        contents.add(Text.of(TextColors.GOLD, "/cs cmd remove", TextColors.GRAY, " - ", TextColors.YELLOW, Lang.HELP_DESC_CMD_COMMANDSIGN_REMOVE));
+
+        PaginationList.builder()
+        .title(Text.of(TextColors.GOLD, "{ ", TextColors.YELLOW, Lang.HELP_HEADER_CMD_COMMANDSIGN, TextColors.GOLD, " }"))
+        .contents(contents)
+        .padding(Text.of("-"))
+        .sendTo(src);
+
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/carrot/carrotshop/command/ShopCommandSignRemoveExecutor.java
+++ b/src/main/java/com/carrot/carrotshop/command/ShopCommandSignRemoveExecutor.java
@@ -1,0 +1,26 @@
+package com.carrot.carrotshop.command;
+
+import com.carrot.carrotshop.ShopsData;
+import com.carrot.carrotshop.util.CommandSignList;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+
+import java.io.File;
+
+public class ShopCommandSignRemoveExecutor implements CommandExecutor {
+
+    @Override
+    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+        File cmdFile = new File(ShopsData.getCmdsDirs(), args.<String>getOne("command").get() + ".txt");
+        cmdFile.delete();
+        if (args.hasAny("l")){
+            CommandSignList.build(src).sendTo(src);
+        }
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/carrot/carrotshop/command/ShopCommandSignSetExecutor.java
+++ b/src/main/java/com/carrot/carrotshop/command/ShopCommandSignSetExecutor.java
@@ -1,0 +1,44 @@
+package com.carrot.carrotshop.command;
+
+import com.carrot.carrotshop.CarrotShop;
+import com.carrot.carrotshop.Lang;
+import com.carrot.carrotshop.ShopsData;
+
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.io.*;
+
+public class ShopCommandSignSetExecutor implements CommandExecutor {
+
+    @Override
+    public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
+        File cmdFile = new File(ShopsData.getCmdsDirs(), args.<String>getOne("name").get() + ".txt");
+        String command = args.<String>getOne("command").get();
+        try{
+            BufferedWriter writer = new BufferedWriter(new FileWriter(cmdFile));
+            writer.write(command);
+            writer.close();
+            src.sendMessage(Text.of(TextColors.DARK_GREEN, "Command set."));
+        } catch (FileNotFoundException e) {
+            CarrotShop.getLogger().info("Cmd file not found: " + cmdFile.getAbsolutePath());
+            if (src instanceof Player) {
+                src.sendMessage(Text.of(TextColors.DARK_RED, Lang.SHOP_CMD_ERROR_FILE404));
+            }
+        } catch (IOException e) {
+            CarrotShop.getLogger().info("Error with cmd file: " + cmdFile.getAbsolutePath());
+            if (src instanceof Player) {
+                src.sendMessage(Text.of(TextColors.DARK_RED, Lang.SHOP_CMD_ERROR));
+            }
+            e.printStackTrace();
+        }
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/carrot/carrotshop/listener/PlayerClickListener.java
+++ b/src/main/java/com/carrot/carrotshop/listener/PlayerClickListener.java
@@ -20,6 +20,7 @@ import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
 import com.carrot.carrotshop.CarrotShop;
+import com.carrot.carrotshop.shop.Cmd;
 import com.carrot.carrotshop.Lang;
 import com.carrot.carrotshop.ShopConfig;
 import com.carrot.carrotshop.ShopsData;
@@ -109,10 +110,19 @@ public class PlayerClickListener {
 				event.setCancelled(true);
 				Shop.build(player, optLoc.get());
 			}
-		} else if (ShopsData.hasMultipleCurrencies() && optItem.isPresent() && optItem.get().getType().equals(ItemTypes.STICK)
+		} else if (optItem.isPresent() && optItem.get().getType().equals(ItemTypes.STICK)
 				&& (optLoc.get().getBlockType() == BlockTypes.STANDING_SIGN || optLoc.get().getBlockType() == BlockTypes.WALL_SIGN)) {
 			Optional<List<Shop>> optShop = ShopsData.getShops(optLoc.get());
-			if (optShop.isPresent()) {
+			if (CarrotShop.getLinkedCommand(player.getUniqueId())!=null && optShop.isPresent() && optShop.get().get(0) instanceof Cmd) {
+				for (Shop shop : optShop.get()){
+					if (shop instanceof Cmd) {
+						event.setCancelled(true);
+						((Cmd)shop).setID(CarrotShop.getLinkedCommand(player.getUniqueId()));
+						player.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.COMANDSIGN_LINKED_SIGN));
+						break;
+					}
+				}
+			} else if (ShopsData.hasMultipleCurrencies()){
 				event.setCancelled(true);
 				for (Shop shop : optShop.get()) {
 					if (shop.canLoopCurrency(player)) {
@@ -120,7 +130,7 @@ public class PlayerClickListener {
 						if (shop.hasCurrency())
 							player.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.split(Lang.CURRENCY_VALUE, "%url%", 0), TextColors.YELLOW, shop.getCurrency().getDisplayName(), TextColors.DARK_GREEN, Lang.split(Lang.CURRENCY_VALUE, "%url%", 1)));
 						else
-							player.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.CURRENCY_SERVER));							
+							player.sendMessage(Text.of(TextColors.DARK_GREEN, Lang.CURRENCY_SERVER));
 					}
 				}
 			}

--- a/src/main/java/com/carrot/carrotshop/shop/Cmd.java
+++ b/src/main/java/com/carrot/carrotshop/shop/Cmd.java
@@ -60,6 +60,10 @@ public class Cmd extends Shop {
 		done(player);
 	}
 
+	public void setID(String id){
+		this.id = id;
+	}
+
 	@Override
 	public void info(Player player) {
 		if (CarrotShop.getEcoService() != null)

--- a/src/main/java/com/carrot/carrotshop/util/CommandSignList.java
+++ b/src/main/java/com/carrot/carrotshop/util/CommandSignList.java
@@ -1,0 +1,45 @@
+package com.carrot.carrotshop.util;
+
+import com.carrot.carrotshop.Lang;
+import com.carrot.carrotshop.ShopsData;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.service.pagination.PaginationList;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.action.TextActions;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CommandSignList {
+    public static PaginationList build(CommandSource src) {
+        File[] Files = ShopsData.getCmdsDirs().listFiles();
+        List<Text> commands = new ArrayList<>();
+        for (File file : Files) {
+            String command = file.getName().substring(0, file.getName().lastIndexOf('.'));
+            Text entry = Text.builder(command)
+                    .append(
+                            Text.builder(" [R]")
+                                    .onClick(TextActions.runCommand("/cs cmd remove " + command + " -l"))
+                                    .onHover(TextActions.showText(Text.of(Lang.HOVER_ACTION_REMOVE + " " + command)))
+                                    .color(TextColors.RED)
+                                    .build(),
+                            Text.builder(" [L]")
+                                    .onClick(TextActions.runCommand("/cs cmd link " + command))
+                                    .onHover(TextActions.showText(Text.of(Lang.HOVER_ACTION_LINK + " " + command)))
+                                    .color(TextColors.YELLOW)
+                                    .build()
+                    )
+                    .build();
+            commands.add(entry);
+        }
+
+        PaginationList result = PaginationList.builder()
+                .title(Text.of(TextColors.GOLD, "{ ", TextColors.YELLOW, Lang.HELP_HEADER_CMD_COMMANDSIGN_LIST, TextColors.GOLD, " }"))
+                .contents(commands)
+                .padding(Text.of("-"))
+                .build();
+        return result;
+    }
+}


### PR DESCRIPTION
Added some commands to manage the commandsigns commands. 
/cs cmd set <name> <command>
Sets a commandsign command. Will create or edit a text file with said content in the commandsign folder basically
/cs cmd remove <name>
deletes a text file in the command directory
/cs cmd link [name]
links a command, so you can  click a commandsign with a stick to change the signs command to the one linked
when used without a name, will unlink the command, freeing you to cycle currencies.
/cs cmd list
lists all the text files in the cmd dir. has a link and delete button you can press.

Basically a project i did for fun to learn java (First time using the language, tbh) 
Originally was going to see if i could convert the storage sources to include some modded ones but sponge doesn't natively support it yet apparently, Oof.
Feel free to add it, modify or reject it. Honestly probs not that secure then again commandsigns run from console anyway so its really just for owners..